### PR TITLE
docs(operations): add local toolchain prerequisites to WSL2 setup guide

### DIFF
--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -8,6 +8,48 @@ inventory stays in `scripts/README.md`.
 
 ## Work Entries
 
+### 2026-05-16 — Cycle 2 implementation: local toolchain setup documentation
+
+- **Date**: 2026-05-16
+- **Layer**: docs, operations
+- **Status**: complete
+- **Tags**: #docs #toolchain #dx #wsl2
+
+#### Progress
+
+- Extended `docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md` in-place with
+  a local toolchain prerequisites section covering: shellcheck, actionlint, zizmor, pre-commit,
+  kube-linter (required tools); graphify, rtk (optional); WSL2 non-interactive shell PATH
+  configuration via `~/.profile` or `/etc/environment`; and local verification commands.
+  Inserted before "Step-by-step Instructions", after existing Prerequisites subsections.
+
+#### Memory
+
+- WSL2 non-interactive shells do not source `.bashrc`/`.zshrc`, so `~/.local/bin` and
+  `~/.go/bin` are absent from PATH. Fix: add `export PATH="$HOME/.local/bin:$(go env GOPATH)/bin:$PATH"`
+  to `~/.profile` or set PATH in `/etc/environment` for system-wide effect.
+- CI uses `pre-commit/action@v3.0.1` which auto-installs all hook dependencies at runtime;
+  CI coverage is complete. Local PATH inconsistency is a DX concern only, not a CI gap.
+- Cycle 2 Batch 2 (harness-catalog.md and agentic.md lifecycle hook boundary documentation):
+  Already implemented in Cycle 1/PR #35. harness-catalog.md Stop/SubagentStop/PreCompact rows
+  already show Partial status with policy-driven remediation notes. agentic.md lines 21 and 49
+  already document the policy-only completion/compaction safeguard boundary.
+
+#### Evidence
+
+- `bash scripts/validate-repo-quality-gates.sh .` PASS
+- `bash scripts/generate-llm-wiki-index.sh --check` PASS
+- `bash infrastructure/tests/verify-contracts-static.sh` PASS
+- `bash scripts/validate-gitops-structure.sh` exit 0, all 11 directories PASS
+- `bash scripts/validate-k8s-manifests.sh .` No lint errors found
+- `bash scripts/check-secret-handling.sh .` PASS
+- `bash -n scripts/*.sh .claude/hooks/*.sh infrastructure/tests/*.sh infrastructure/*.sh` PASS
+- Changed file: `docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md` (+60 lines)
+- Skipped: cluster bootstrap (BLOCKED, requires human approval); per-service README files
+  (DEFERRED, no human request); Batch 3 aggregate service docs (DEFERRED, requires human approval).
+
+---
+
 ### 2026-05-15 — Workspace audit pipeline: housekeeping and quality-gate alignment
 
 - **Date**: 2026-05-15

--- a/docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md
+++ b/docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md
@@ -57,6 +57,66 @@ docker inspect vault --format '{{(index .NetworkSettings.Networks "k3d-hyhome").
 docker network connect k3d-hyhome vault
 ```
 
+### 로컬 툴체인 사전 요구사항
+
+정적 검증과 pre-commit 훅을 로컬에서 실행하려면 아래 도구가 필요하다.
+CI에서는 `pre-commit/action@v3.0.1`이 모든 도구를 자동 설치하므로 CI 커버리지에는 영향이 없다.
+로컬 PATH 설정이 불일치하면 pre-commit 훅이 조용히 스킵될 수 있다.
+
+#### 필수 도구 설치
+
+```bash
+# pre-commit (훅 러너)
+pip install pre-commit
+# 또는: pip3 install pre-commit
+
+# shellcheck (셸 스크립트 린팅) — Ubuntu/Debian
+sudo apt-get install shellcheck
+
+# actionlint (GitHub Actions 워크플로우 린팅)
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+# zizmor (워크플로우 보안 스캐닝)
+pip install zizmor
+
+# kube-linter (Kubernetes 매니페스트 린팅)
+go install golang.stackrox.io/kube-linter/cmd/kube-linter@latest
+```
+
+#### 선택 도구 설치
+
+```bash
+# graphify (지식 그래프, 선택사항)
+# rtk (Codex CLI 프록시, 선택사항)
+which graphify rtk 2>/dev/null || echo "Optional tools not installed — CI unaffected"
+```
+
+#### WSL2 비대화형 셸 PATH 설정
+
+WSL2 비대화형 셸(pre-commit, CI 에뮬레이션)은 `.bashrc`/`.zshrc`를 로드하지 않으므로
+`~/.local/bin`, `~/.go/bin` 등이 PATH에서 누락될 수 있다.
+
+```bash
+# ~/.profile에 추가 (로그인 셸에서 적용)
+echo 'export PATH="$HOME/.local/bin:$(go env GOPATH)/bin:$PATH"' >> ~/.profile
+
+# 시스템 전체 적용이 필요한 경우 /etc/environment 수정 (sudo 필요, 재부팅 후 적용)
+# sudo sed -i 's|PATH="|PATH="/home/<user>/.local/bin:/home/<user>/go/bin:|' /etc/environment
+```
+
+#### 설치 검증
+
+```bash
+command -v shellcheck actionlint zizmor pre-commit kube-linter
+# 각 도구가 경로를 출력하면 정상
+
+pre-commit run --all-files  # 로컬 전체 pre-commit 검증
+```
+
+> **참고**: CI는 `.github/workflows/ci.yml`의 `pre-commit/action@v3.0.1`이 actionlint, zizmor,
+> shellcheck, kube-linter 등을 런타임에 자동 설치한다. 로컬 PATH 불일치는 로컬 개발자 경험(DX)
+> 문제이며 CI 커버리지에는 영향이 없다.
+
 ## Step-by-step Instructions
 
 1. 클러스터 baseline을 생성/확인한다.


### PR DESCRIPTION
## Summary

Extends `docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md` in-place with a **로컬 툴체인 사전 요구사항** (Local Toolchain Prerequisites) section.

### Why

The guide referenced `actionlint` and `zizmor` as CI validation tools (lines 246–247) but provided no local installation or PATH guidance. Developers without correct PATH setup in WSL2 non-interactive shells miss local pre-commit feedback before push.

CI coverage via `pre-commit/action@v3.0.1` is complete and authoritative; this change closes the local DX gap only.

### What changed

- **`docs/05.operations/guides/0002-wsl2-k3d-argocd-ha-setup-guide.md`** (+60 lines):
  - Required tools: `shellcheck` (apt-get), `actionlint` (go install), `zizmor` (pip), `pre-commit` (pip), `kube-linter` (go install)
  - Optional tools: `graphify`, `rtk`
  - WSL2 non-interactive shell PATH fix via `~/.profile` or `/etc/environment`
  - Local verification: `command -v` check; `pre-commit run --all-files`
  - Note: CI uses `pre-commit/action@v3.0.1` (auto-installs all); local PATH is DX only

- **`docs/00.agent-governance/memory/progress.md`** (+42 lines): Cycle 2 implementation evidence entry (English-only, per governance language boundary rule).

### Change type

- [x] docs

### Verification evidence

- `bash scripts/validate-repo-quality-gates.sh .` → PASS
- `bash scripts/generate-llm-wiki-index.sh --check` → PASS
- `bash infrastructure/tests/verify-contracts-static.sh` → PASS
- `bash scripts/validate-gitops-structure.sh` → exit 0 (all 11 directories)
- `bash scripts/validate-k8s-manifests.sh .` → No lint errors found
- `bash scripts/check-secret-handling.sh .` → PASS
- `bash -n scripts/*.sh .claude/hooks/*.sh infrastructure/tests/*.sh infrastructure/*.sh` → PASS

### Coverage policy

Validation-matrix coverage applies (Bash/Markdown infrastructure change). No application code added.

### Not included

- Cluster bootstrap (blocked — requires explicit human approval)
- Per-service README files (no human request for new files)