### PR TITLE
ci(governance): Align stale action inventory

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v10.2.0
         with:
           stale-issue-message:
             "This issue is stale because it has been open 30 days with no

--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -28,13 +28,14 @@ inventory stays in `scripts/README.md`.
   not enforce admins.
 - Confirmed latest main commit `d8b9c19` has successful CI, including
   `ci-summary`.
-- Found open Dependabot PR #38 failing because `actions/stale` changed to
-  `v10.2.0` without the matching version inventory update.
+- Found Dependabot PR #38 failing because `actions/stale` changed to `v10.2.0`
+  without the matching version inventory update.
 - Updated `.github/workflows/stale.yml` and
   `docs/90.references/versions/tech-stack-version-inventory.md` together to
   `actions/stale@v10.2.0` on a `codex/` branch instead of bypassing `main`.
 - Opened replacement PR #39 and confirmed its remote CI passed, including
   `ci-summary`, `pre-commit`, `repo-quality-static`, and `branch-policy`.
+- Closed PR #38 as superseded by PR #39 to remove the stale failing duplicate.
 
 #### Memory
 

--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -8,6 +8,57 @@ inventory stays in `scripts/README.md`.
 
 ## Work Entries
 
+### 2026-05-25 — approval-bound completion audit
+
+- **Date**: 2026-05-25
+- **Layer**: ci, qa, docs, runtime
+- **Status**: partial
+- **Tags**: #ci #github #runtime #validation #version-inventory
+
+#### Progress
+
+- Added VAL-SPC-006-019 plus T-076 through T-079 to the existing 006 SDD
+  chain for the approval-bound completion audit.
+- Re-ran approved read-only live checks. Docker context is `default`, no Docker
+  containers are running, no k3d clusters are listed, and the `k3d-hyhome`
+  Kubernetes API at `https://0.0.0.0:6550` refuses connection.
+- Queried GitHub remote state. The repository has no rulesets returned by the
+  rulesets API; main branch protection requires `ci-summary`, has PR review
+  settings with zero required approvals, disables force-push/deletion, and does
+  not enforce admins.
+- Confirmed latest main commit `d8b9c19` has successful CI, including
+  `ci-summary`.
+- Found open Dependabot PR #38 failing because `actions/stale` changed to
+  `v10.2.0` without the matching version inventory update.
+- Updated `.github/workflows/stale.yml` and
+  `docs/90.references/versions/tech-stack-version-inventory.md` together to
+  `actions/stale@v10.2.0` on a `codex/` branch instead of bypassing `main`.
+
+#### Memory
+
+- Branch protection, not repository rulesets, is the current remote policy SSoT
+  for `main`.
+- `ci-summary` is the required status check; direct pushes by admins can bypass
+  PR routing but should not be used for normal follow-up work.
+- Live runtime proof remains a current-state limitation when Docker has no
+  running containers and k3d has no cluster rows.
+
+#### Evidence
+
+- 006 Spec/Plan/Task include the approval-bound completion audit overlay.
+- `gh run view` for `d8b9c19` shows successful main CI.
+- `gh pr view 38` and `gh run view 26363778043 --job 77603867367 --log` show
+  the open Dependabot PR failure and `actions/stale` version drift.
+
+#### Handoff
+
+- This branch should be opened as a PR and merged through the normal protected
+  branch path after CI passes.
+- Do not inspect secret values, run Vault KV reads/writes, force ArgoCD sync, or
+  run cluster mutation commands as part of this audit.
+
+---
+
 ### 2026-05-25 — task-unit commit follow-up
 
 - **Date**: 2026-05-25

--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -8,6 +8,39 @@ inventory stays in `scripts/README.md`.
 
 ## Work Entries
 
+### 2026-05-25 — approval-bound evidence refresh
+
+- **Date**: 2026-05-25
+- **Layer**: ci, docs
+- **Status**: complete
+- **Tags**: #ci #github #validation #evidence
+
+#### Progress
+
+- Rechecked PR #39 after the approval-bound audit branch updates.
+- Confirmed PR #39 is open, mergeable, non-draft, and has passing checks for
+  `ci-summary`, `pre-commit`, `repo-quality-static`, `branch-policy`,
+  `changes`, `label`, and GitGuardian.
+- Corrected the 006 Plan/Task PR check evidence to remove the stale `greeting`
+  check name, which is not present in the current GitHub check rollup.
+
+#### Memory
+
+- Treat PR check evidence as current-state data. Re-run `gh pr view ...` before
+  copying check names into authored SSoT artifacts.
+
+#### Evidence
+
+- `gh pr view 39 --json number,state,isDraft,mergeable,statusCheckRollup` PASS.
+- 006 Task includes T-080 for this evidence refresh.
+
+#### Handoff
+
+- PR #39 still requires normal protected-branch handling before the branch can
+  become the `main` SSoT.
+
+---
+
 ### 2026-05-25 — approval-bound completion audit
 
 - **Date**: 2026-05-25

--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -12,7 +12,7 @@ inventory stays in `scripts/README.md`.
 
 - **Date**: 2026-05-25
 - **Layer**: ci, qa, docs, runtime
-- **Status**: partial
+- **Status**: complete
 - **Tags**: #ci #github #runtime #validation #version-inventory
 
 #### Progress
@@ -33,6 +33,8 @@ inventory stays in `scripts/README.md`.
 - Updated `.github/workflows/stale.yml` and
   `docs/90.references/versions/tech-stack-version-inventory.md` together to
   `actions/stale@v10.2.0` on a `codex/` branch instead of bypassing `main`.
+- Opened replacement PR #39 and confirmed its remote CI passed, including
+  `ci-summary`, `pre-commit`, `repo-quality-static`, and `branch-policy`.
 
 #### Memory
 
@@ -52,8 +54,8 @@ inventory stays in `scripts/README.md`.
 
 #### Handoff
 
-- This branch should be opened as a PR and merged through the normal protected
-  branch path after CI passes.
+- PR #39 should be merged through the normal protected branch path; do not
+  repeat direct `main` bypass for this follow-up.
 - Do not inspect secret values, run Vault KV reads/writes, force ArgoCD sync, or
   run cluster mutation commands as part of this audit.
 

--- a/docs/03.specs/006-workspace-harness-gap-analysis/spec.md
+++ b/docs/03.specs/006-workspace-harness-gap-analysis/spec.md
@@ -246,6 +246,10 @@ git diff --check
   lifecycle hook guidance for dirty states that span multiple logical units, and
   preserves task-unit staging and `git diff --cached` review as the required
   path for future human-requested commits without rewriting public history.
+- **VAL-SPC-006-019**: 2026-05-25 approval-bound completion audit records fresh
+  read-only runtime and GitHub remote evidence, keeps unavailable live k3d state
+  as a current-state limitation, and remediates the discovered CI version
+  inventory drift for `actions/stale` without direct main-branch bypass.
 
 ## Related Documents
 

--- a/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
@@ -1921,7 +1921,7 @@ or `kubectl patch`, rewrite public history, or bypass `main` branch protection.
 | Workflow YAML parse | PASS | `.github/workflows/stale.yml` remains parseable |
 | LLM Wiki index | PASS | Generated index freshness |
 | Git diff whitespace | PASS | No whitespace errors |
-| PR checks | PASS | PR #39 passed `ci-summary`, `pre-commit`, `repo-quality-static`, `branch-policy`, `changes`, `greeting`, `label`, and GitGuardian checks; manifest/shell jobs skipped by path-filter design |
+| PR checks | PASS | PR #39 passed `ci-summary`, `pre-commit`, `repo-quality-static`, `branch-policy`, `changes`, `label`, and GitGuardian checks; manifest/shell jobs skipped by path-filter design |
 
 ## Related Documents
 

--- a/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
@@ -1921,7 +1921,7 @@ or `kubectl patch`, rewrite public history, or bypass `main` branch protection.
 | Workflow YAML parse | PASS | `.github/workflows/stale.yml` remains parseable |
 | LLM Wiki index | PASS | Generated index freshness |
 | Git diff whitespace | PASS | No whitespace errors |
-| PR checks | Pending until remote CI runs | This branch should avoid direct `main` bypass |
+| PR checks | PASS | PR #39 passed `ci-summary`, `pre-commit`, `repo-quality-static`, `branch-policy`, `changes`, `greeting`, `label`, and GitGuardian checks; manifest/shell jobs skipped by path-filter design |
 
 ## Related Documents
 

--- a/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
@@ -1902,7 +1902,7 @@ or `kubectl patch`, rewrite public history, or bypass `main` branch protection.
 | GitHub branch protection | `gh api .../branches/main/protection` | `ci-summary` required; PR review settings present with zero required approvals; admin enforcement disabled; force-push/deletion disabled | Avoid direct main bypass; use branch/PR for follow-up |
 | GitHub rulesets | `gh api .../rulesets` | no repository rulesets returned | Branch protection is the active remote policy evidence |
 | Main CI | `gh run view` and check-runs for `d8b9c19` | latest main CI completed successfully | Main branch repo-static state is green |
-| Open PR #38 | `gh pr view` and failed repo-quality logs | `actions/stale` drift to `v10.2.0` without version inventory update | Create replacement remediation branch/PR |
+| Dependabot PR #38 | `gh pr view`, failed repo-quality logs, and `gh pr close` | `actions/stale` drift to `v10.2.0` without version inventory update; closed as superseded by PR #39 | Keep replacement remediation in PR #39 |
 
 ### Implementation Plan Delta
 

--- a/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
@@ -1881,6 +1881,48 @@ Kubernetes mutation, ArgoCD sync, or Vault write is included.
 | Lifecycle hook self-test | PASS | Stop and PreCompact mention task-unit discipline, multi-unit dirty states, and `git diff --cached` |
 | Git status | clean and synced after push | No history rewrite |
 
+## Approval-Bound Completion Audit Overlay - 2026-05-25
+
+### Intent and Boundary
+
+This overlay implements the approved follow-up review for items that were
+previously blocked by approval or external state. It performs read-only live
+runtime checks and GitHub remote inspection, then remediates the repo-backed CI
+version inventory drift discovered from open PR evidence. It does not inspect
+secret values, run Vault KV reads/writes, force ArgoCD sync, run `kubectl apply`
+or `kubectl patch`, rewrite public history, or bypass `main` branch protection.
+
+### Current-State Audit
+
+| Area | Evidence | Current result | Decision |
+| --- | --- | --- | --- |
+| Docker/k3d | `docker context show`; `docker ps`; `k3d cluster list` | Docker context is `default`; no running containers; no k3d clusters listed | Live platform proof remains unavailable in current WSL state |
+| Kubernetes API | `kubectl config current-context`; read-only `kubectl get` | context is `k3d-hyhome`; API `https://0.0.0.0:6550` refuses connection | Record current-state fail; do not treat as live success |
+| ArgoCD/ESO metadata | read-only `kubectl get` only | same API refusal | Defer runtime metadata proof until cluster exists |
+| GitHub branch protection | `gh api .../branches/main/protection` | `ci-summary` required; PR review settings present with zero required approvals; admin enforcement disabled; force-push/deletion disabled | Avoid direct main bypass; use branch/PR for follow-up |
+| GitHub rulesets | `gh api .../rulesets` | no repository rulesets returned | Branch protection is the active remote policy evidence |
+| Main CI | `gh run view` and check-runs for `d8b9c19` | latest main CI completed successfully | Main branch repo-static state is green |
+| Open PR #38 | `gh pr view` and failed repo-quality logs | `actions/stale` drift to `v10.2.0` without version inventory update | Create replacement remediation branch/PR |
+
+### Implementation Plan Delta
+
+| Priority | Action type | Target | Change | Linked task | Verification | Rollback |
+| --- | --- | --- | --- | --- | --- | --- |
+| P1 | supplementation | Spec 006 | Add VAL-SPC-006-019 for approval-bound completion audit | T-076 | repo quality gate | Revert criterion |
+| P1 | supplementation | 006 Plan/Task | Add this audit overlay and T-076 through T-079 | T-076, T-079 | repo quality gate; wiki check | Revert overlay sections |
+| P1 | CI/version inventory | `.github/workflows/stale.yml`; version inventory | Align `actions/stale` pin and SSoT inventory to `v10.2.0` | T-077 | repo quality gate; workflow parse | Revert both files together |
+| P1 | memory | progress ledger | Record live unavailable state, GitHub remote policy, and PR replacement boundary | T-078 | repo quality gate | Revert progress entry |
+
+### Verification Delta
+
+| Check | Expected result | Notes |
+| --- | --- | --- |
+| Repo quality gate | PASS | Version inventory must match workflow pin |
+| Workflow YAML parse | PASS | `.github/workflows/stale.yml` remains parseable |
+| LLM Wiki index | PASS | Generated index freshness |
+| Git diff whitespace | PASS | No whitespace errors |
+| PR checks | Pending until remote CI runs | This branch should avoid direct `main` bypass |
+
 ## Related Documents
 
 - **Spec**: [../../03.specs/006-workspace-harness-gap-analysis/spec.md](../../03.specs/006-workspace-harness-gap-analysis/spec.md)

--- a/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
@@ -130,6 +130,10 @@ pre-check와 follow-up으로 남긴다.
 | T-073 | Strengthen lifecycle hook dirty-state guidance for multi-unit changes | guardrail | VAL-SPC-006-018 | Task-Unit Commit P1 | lifecycle hook self-test | Platform | Done |
 | T-074 | Extend repo-quality hook simulation to cover the stronger commit guidance | test | VAL-SPC-006-018 | Task-Unit Commit P1 | repo quality gate | Platform | Done |
 | T-075 | Run follow-up verification and create one forward-only corrective commit | test | VAL-SPC-006-018 | Task-Unit Commit Verification | Task-Unit Commit Follow-up Verification Summary | Platform | Done |
+| T-076 | Run approval-bound completion audit for live runtime and GitHub remote state | eval | VAL-SPC-006-019 | Approval-Bound Audit | Approval-Bound Completion Audit Summary | Platform | Done |
+| T-077 | Remediate discovered `actions/stale` workflow and version inventory drift | ci | VAL-SPC-006-019 | Approval-Bound P1 | repo quality gate and workflow parse | Platform | Done |
+| T-078 | Record remaining current-state limitations and replacement PR boundary | doc | VAL-SPC-006-019 | Approval-Bound Audit | progress ledger and PR evidence | Platform | Done |
+| T-079 | Run verification for the approval-bound audit branch and PR | test | VAL-SPC-006-019 | Approval-Bound Verification | Approval-Bound Completion Audit Summary | Platform | Done |
 
 ## Suggested Types
 
@@ -267,6 +271,13 @@ pre-check와 follow-up으로 남긴다.
 - [x] T-073 Strengthen lifecycle hook dirty-state guidance.
 - [x] T-074 Cover the stronger advisory in repo-quality self-tests.
 - [x] T-075 Run verification and create one forward-only corrective commit.
+
+### Phase 17 - Approval-Bound Completion Audit
+
+- [x] T-076 Run read-only live runtime and GitHub remote state audit.
+- [x] T-077 Align `actions/stale` workflow pin and version inventory.
+- [x] T-078 Record remaining current-state limitations and PR boundary.
+- [x] T-079 Run verification for the audit branch and PR.
 
 ## Verification Evidence History Note
 
@@ -695,6 +706,49 @@ is stored in the linked plan to keep this task document concise.
   - Future human-requested commits must split dirty states that span multiple
     SDD overlays, runtime docs, hooks, validators, or env contracts before
     commit, stage only the files for the unit, and review `git diff --cached`.
+
+## Approval-Bound Completion Audit Summary
+
+- **Scope**: 2026-05-25 follow-up after the human approved approval-bound
+  review items. This audit covers read-only live/runtime checks, GitHub remote
+  policy/CI state, and CI version inventory drift discovered during that audit.
+- **Runtime Evidence**:
+  - `docker context show` - PASS; current context is `default`.
+  - `docker ps --format ...` - CURRENT-STATE INFO; no running containers.
+  - `k3d cluster list` - CURRENT-STATE INFO; no cluster rows.
+  - `kubectl config current-context` - PASS; current context is `k3d-hyhome`.
+  - `kubectl get nodes -o wide --request-timeout=5s` - CURRENT-STATE FAIL;
+    Kubernetes API `https://0.0.0.0:6550` refused connection.
+  - Read-only ArgoCD, ESO, ClusterSecretStore, ExternalSecret, AppProject, and
+    ApplicationSet metadata checks - CURRENT-STATE FAIL for the same
+    unavailable API server.
+- **GitHub Remote Evidence**:
+  - `gh repo view buenhyden/hy-home.k8s` - PASS; default branch is `main`,
+    repository is public, viewer permission is `ADMIN`.
+  - `gh api repos/buenhyden/hy-home.k8s/rulesets` - PASS; no repository
+    rulesets returned.
+  - `gh api repos/buenhyden/hy-home.k8s/branches/main/protection` - PASS;
+    branch protection requires `ci-summary`, pull request review settings exist
+    with zero required approvals, force-push and deletion are disabled, and
+    admin enforcement is disabled.
+  - Latest `d8b9c19` main CI run - PASS; `ci-summary`, `repo-quality-static`,
+    `pre-commit`, and `shell-static` passed; `manifest-static` and
+    `branch-policy` skipped by path/branch policy design.
+  - Open Dependabot PR #38 - FAIL; `repo-quality-static` and `ci-summary`
+    failed because `actions/stale` changed to `v10.2.0` without matching
+    `docs/90.references/versions/tech-stack-version-inventory.md` and the PR
+    was based on stale main state.
+- **Repo Change**:
+  - Updated `.github/workflows/stale.yml` and
+    `docs/90.references/versions/tech-stack-version-inventory.md` together to
+    `actions/stale@v10.2.0`.
+- **Remaining Limitations**:
+  - Live k3d/ArgoCD/ESO/Vault metadata cannot be proven until the local
+    `k3d-hyhome` cluster exists and the API server is reachable.
+  - Secret values and Vault KV values remain intentionally unprinted and
+    uninspected by the agent.
+  - Direct main-branch bypass should not be repeated; this remediation is
+    carried on a `codex/` branch and should enter `main` through PR review.
 
 ## Related Documents
 

--- a/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
@@ -738,6 +738,10 @@ is stored in the linked plan to keep this task document concise.
     failed because `actions/stale` changed to `v10.2.0` without matching
     `docs/90.references/versions/tech-stack-version-inventory.md` and the PR
     was based on stale main state.
+  - Replacement PR #39 - PASS; `ci-summary`, `pre-commit`,
+    `repo-quality-static`, `branch-policy`, `changes`, `greeting`, `label`, and
+    GitGuardian checks passed. `manifest-static` and `shell-static` skipped by
+    workflow path-filter design.
 - **Repo Change**:
   - Updated `.github/workflows/stale.yml` and
     `docs/90.references/versions/tech-stack-version-inventory.md` together to

--- a/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
@@ -734,8 +734,9 @@ is stored in the linked plan to keep this task document concise.
   - Latest `d8b9c19` main CI run - PASS; `ci-summary`, `repo-quality-static`,
     `pre-commit`, and `shell-static` passed; `manifest-static` and
     `branch-policy` skipped by path/branch policy design.
-  - Open Dependabot PR #38 - FAIL; `repo-quality-static` and `ci-summary`
-    failed because `actions/stale` changed to `v10.2.0` without matching
+  - Dependabot PR #38 - CLOSED as superseded by PR #39; before closure,
+    `repo-quality-static` and `ci-summary` failed because `actions/stale`
+    changed to `v10.2.0` without matching
     `docs/90.references/versions/tech-stack-version-inventory.md` and the PR
     was based on stale main state.
   - Replacement PR #39 - PASS; `ci-summary`, `pre-commit`,

--- a/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
@@ -134,6 +134,7 @@ pre-check와 follow-up으로 남긴다.
 | T-077 | Remediate discovered `actions/stale` workflow and version inventory drift | ci | VAL-SPC-006-019 | Approval-Bound P1 | repo quality gate and workflow parse | Platform | Done |
 | T-078 | Record remaining current-state limitations and replacement PR boundary | doc | VAL-SPC-006-019 | Approval-Bound Audit | progress ledger and PR evidence | Platform | Done |
 | T-079 | Run verification for the approval-bound audit branch and PR | test | VAL-SPC-006-019 | Approval-Bound Verification | Approval-Bound Completion Audit Summary | Platform | Done |
+| T-080 | Refresh PR #39 check evidence against the current GitHub check rollup | doc | VAL-SPC-006-019 | Approval-Bound Evidence Refresh | PR #39 check rollup and repo quality gate | Platform | Done |
 
 ## Suggested Types
 
@@ -278,6 +279,7 @@ pre-check와 follow-up으로 남긴다.
 - [x] T-077 Align `actions/stale` workflow pin and version inventory.
 - [x] T-078 Record remaining current-state limitations and PR boundary.
 - [x] T-079 Run verification for the audit branch and PR.
+- [x] T-080 Refresh PR #39 check evidence against the current GitHub check rollup.
 
 ## Verification Evidence History Note
 
@@ -740,9 +742,9 @@ is stored in the linked plan to keep this task document concise.
     `docs/90.references/versions/tech-stack-version-inventory.md` and the PR
     was based on stale main state.
   - Replacement PR #39 - PASS; `ci-summary`, `pre-commit`,
-    `repo-quality-static`, `branch-policy`, `changes`, `greeting`, `label`, and
-    GitGuardian checks passed. `manifest-static` and `shell-static` skipped by
-    workflow path-filter design.
+    `repo-quality-static`, `branch-policy`, `changes`, `label`, and GitGuardian
+    checks passed. `manifest-static` and `shell-static` skipped by workflow
+    path-filter design.
 - **Repo Change**:
   - Updated `.github/workflows/stale.yml` and
     `docs/90.references/versions/tech-stack-version-inventory.md` together to

--- a/docs/90.references/versions/tech-stack-version-inventory.md
+++ b/docs/90.references/versions/tech-stack-version-inventory.md
@@ -116,7 +116,7 @@ github_actions:
   'actions/first-interaction': 'v3'
   'actions/labeler': 'v6.1.0'
   'actions/setup-python': 'v6'
-  'actions/stale': 'v10'
+  'actions/stale': 'v10.2.0'
   'actions/upload-artifact': 'v7'
   'dorny/paths-filter': 'v4.0.1'
   'orhun/git-cliff-action': 'v4'


### PR DESCRIPTION
## 1. Description

Align the stale workflow action pin with the repo-backed tech stack version inventory, and record the approval-bound completion audit in the existing 006 SDD chain.

## 2. Related Issue

Related to Dependabot PR #38 failing repo-quality-static because actions/stale moved to v10.2.0 without a matching version inventory update.

## 3. Branch Target

- [x] This PR targets main; any exception must update CI branch-policy and governance in the same change.
- [x] No PR targeting main bypasses CI or branch-policy checks.
- [x] Draft/WIP status is intentional; this PR is not ready for review or merge until required checks pass and verification evidence is complete.
- [x] The source branch uses an approved prefix: codex/.
- [x] CI branch-policy validates pull request shape; GitHub branch protection/rulesets enforce direct-push restrictions.

## 4. Type of Change

- [x] ci: Changes to GitHub Actions, hooks, or automation
- [x] docs: Documentation updates

## 5. Breaking Changes

- [x] No

## 6. How Has This Been Tested?

- [x] Relevant pre-commit hooks passed
- [x] bash scripts/validate-repo-quality-gates.sh . successful
- [x] bash scripts/generate-llm-wiki-index.sh --check successful
- [x] workflow YAML parse successful for .github/workflows/*.yml
- [x] git diff --check successful
- [x] No live cluster mutation, kubectl apply, or external Vault mutation was introduced

## 7. Checklist

- [x] My change follows the governance and workflow rules in AGENTS.md and docs/00.agent-governance/.
- [x] I have updated the documentation accordingly.
- [x] My commit messages follow Conventional Commits.
- [x] I did not introduce plaintext secrets. Secret-related changes use GitOps-approved patterns only.

## Impact Area

- GitHub Actions stale workflow pin
- docs/90.references version inventory
- Spec 006 / Plan 006 / Task 006 approval-bound audit evidence

## Runtime Boundary

Read-only runtime checks were attempted and recorded. The local k3d API remains unavailable in the current WSL state; this PR does not start clusters or mutate runtime state.