### PR TITLE
fix(runtime): Close live bootstrap validation gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,9 @@ ROOT_CA_KEY_FILE=secrets/certs/rootCA-key.pem
 
 # ── k3d 포트 바인딩 ───────────────────────────────────────
 # 기본 direct host 포트는 80/443 이다. bootstrap-local.sh 는 호스트 443 이
-# 이미 사용 중이면 direct fallback 용 HTTPS 포트를 8443 으로 바꿀 수 있다.
-# 외부 Traefik dynamic config 는 Docker 네트워크의 k3d-hyhome-serverlb:443 을
-# backend 로 사용하므로 direct fallback 포트와 혼동하지 않는다.
+# 이미 사용 중이면 k3d serverlb host binding 용 HTTPS 포트를 8443 으로 바꿀 수 있다.
+# 외부 Traefik dynamic config 는 ingress-nginx LoadBalancer IP(기본 172.18.0.240):443 을
+# backend 로 사용하므로 host-port fallback 값과 혼동하지 않는다.
 K3D_HTTP_PORT=80
 K3D_HTTPS_PORT=443
 

--- a/docs/00.agent-governance/memory/progress.md
+++ b/docs/00.agent-governance/memory/progress.md
@@ -8,6 +8,70 @@ inventory stays in `scripts/README.md`.
 
 ## Work Entries
 
+### 2026-05-25 — live bootstrap runtime closure
+
+- **Date**: 2026-05-25
+- **Layer**: runtime, gitops, docs, qa
+- **Status**: complete
+- **Tags**: #runtime #bootstrap #gitops #vault #validation
+
+#### Progress
+
+- Continued after PR #40 was merged into `main` and created
+  `codex/live-bootstrap-runtime-closure` for forward-only follow-up work.
+- Started the approved local runtime dependencies for verification: k3d
+  `hyhome`, Vault, Valkey, PostgreSQL router, and required PostgreSQL cluster
+  dependencies. Secret values were not printed.
+- Fixed live bootstrap blockers found during the run:
+  - MetalLB `0.16.0` needed explicit
+    `frr-k8s.prometheus.serviceMonitor.enabled=false` and a 300s wait timeout
+    for cold image pulls.
+  - ArgoCD excludes EndpointSlice resources, so bootstrap must initialize all
+    external-service `Service` and `EndpointSlice` objects before ESO/Vault
+    validation.
+  - Vault Kubernetes auth needed the current k3d reviewer JWT/CA and a
+    GitOps-owned `system:auth-delegator` ClusterRoleBinding for the
+    `external-secrets` serviceAccount.
+  - Live TLS validation must use ingress-nginx `LoadBalancer` IP with
+    host/SNI resolve by default; external Traefik host 443 remains optional
+    runtime proof.
+- Updated the 006 Spec/Plan/Task chain with VAL-SPC-006-021 and T-084 through
+  T-090.
+
+#### Memory
+
+- For this repo's current k3d + MetalLB topology, external Traefik dynamic
+  config should target ingress-nginx `LoadBalancer` IP `172.18.0.240:443`,
+  not the k3d serverlb DNS backend.
+- EndpointSlice desired state remains in `gitops/platform/external-services/`,
+  but ArgoCD exclusion means bootstrap or human-approved break-glass must apply
+  those EndpointSlices in the live cluster.
+- Vault Kubernetes auth can show `token_reviewer_jwt_set=True` and still fail
+  after cluster recreation if the reviewer token/CA is stale or the reviewer
+  serviceAccount lacks TokenReview permission.
+
+#### Evidence
+
+- `infrastructure/bootstrap-local.sh` PASS.
+- Vault Kubernetes login metadata check returned HTTP `200`; tokens were not
+  printed.
+- `kubectl auth can-i create tokenreviews.authentication.k8s.io --as system:serviceaccount:external-secrets:external-secrets` PASS.
+- `bash infrastructure/tests/verify-secrets.sh` PASS.
+- `bash infrastructure/tests/run-all.sh` PASS.
+- Repo-static validation bundle PASS: repo quality gate, LLM Wiki check, GitOps
+  structure, Kubernetes manifest syntax, secret handling, static contracts,
+  shell syntax, JSON parse, workflow/Traefik YAML parse, env key-name-only
+  comparison, and `git diff --check`.
+- 006 Spec/Plan/Task include VAL-SPC-006-021 and T-084 through T-090.
+
+#### Handoff
+
+- External Traefik gateway runtime proof with `CHECK_TRAEFIK_443=true` remains a
+  separate approved run because this closure did not start or mutate the
+  external gateway service.
+
+---
+
 ### 2026-05-25 — post-merge completion audit
 
 - **Date**: 2026-05-25
@@ -243,8 +307,9 @@ inventory stays in `scripts/README.md`.
   T-063 through T-070 for deferred item repo-static improvements.
 - Clarified EndpointSlice desired-state ownership versus human-approved
   break-glass patch/apply boundaries.
-- Separated external Traefik `websecure/443 -> k3d-hyhome-serverlb:443` wording
-  from direct host fallback `ARGOCD_FALLBACK_PORT=8443` checks.
+- Separated external Traefik backend wording from direct host fallback checks.
+  VAL-SPC-006-021 later superseded the backend target with ingress-nginx
+  `LoadBalancer` IP evidence.
 - Aligned operations policy wording with current CI job names and recorded that
   OPA/Conftest remains deferred until owner, bundle, install path, and failure
   semantics exist.
@@ -259,9 +324,9 @@ inventory stays in `scripts/README.md`.
 
 - For deferred-item follow-ups, split repo-static wording fixes from live proof,
   remote ruleset review, secret value review, and actual deletion/consolidation.
-- Traefik backend port and direct fallback port are different contracts:
-  Docker-network backend stays `k3d-hyhome-serverlb:443`; direct fallback may be
-  `8443` when host 443 is unavailable.
+- Traefik backend port and direct fallback port are different contracts. This
+  entry is historical; current backend target is maintained by VAL-SPC-006-021
+  as ingress-nginx `LoadBalancer` IP `172.18.0.240:443`.
 - OPA/Conftest should not become a required gate without a named policy owner,
   policy bundle location, installation contract, and failure semantics.
 

--- a/docs/03.specs/006-workspace-harness-gap-analysis/spec.md
+++ b/docs/03.specs/006-workspace-harness-gap-analysis/spec.md
@@ -254,6 +254,11 @@ git diff --check
   merged into `main`, verifies the merge commit's CI and local static gates,
   and keeps live bootstrap/runtime proof deferred because approved prechecks
   show Vault, PostgreSQL, and Valkey are currently unreachable.
+- **VAL-SPC-006-021**: 2026-05-25 live bootstrap runtime closure records the
+  approved external-service startup, k3d bootstrap, Vault Kubernetes auth
+  repair, EndpointSlice bootstrap boundary correction, MetalLB/Traefik
+  validation fixes, and successful `infrastructure/tests/run-all.sh` evidence
+  without printing secret values or rewriting public history.
 
 ## Related Documents
 

--- a/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/plans/2026-05-24-workspace-harness-gap-analysis.md
@@ -1806,7 +1806,7 @@ rulesets, and it does not inspect secret values.
 | Deferred item | Repo-static change | Evidence path | Status after this overlay | Remaining non-static boundary |
 | --- | --- | --- | --- | --- |
 | EndpointSlice ownership ambiguity | Clarify that `gitops/platform/external-services/*.yaml` is the desired-state SSoT, while direct EndpointSlice patch/apply remains human-approved break-glass when ArgoCD resource exclusions or runtime drift prevent reconciliation | `gitops/README.md`; `docs/05.operations/policies/0002-wsl2-k3d-gitops-ha-operations-policy.md` | improved repo-static | live reconciliation proof and any direct cluster hotfix |
-| Traefik backend/fallback port wording drift | Separate external Traefik `websecure/443 -> k3d-hyhome-serverlb:443` from direct host fallback `ARGOCD_FALLBACK_PORT=8443` checks | `traefik/README.md`; operations policy | improved repo-static | live TLS reachability |
+| Traefik backend/fallback port wording drift | Superseded by VAL-SPC-006-021 live evidence: external Traefik backend should target ingress-nginx `LoadBalancer` IP `172.18.0.240:443`; direct host fallback remains explicit-only | `traefik/README.md`; operations policy; live closure overlay | improved with live correction | external Traefik gateway runtime proof |
 | `workflow-security` policy wording drift | Replace stale `workflow-security` job wording with current CI gate names: `branch-policy`, `pre-commit`, `repo-quality-static`, `manifest-static`, and `shell-static` | operations policy; `.github/workflows/ci.yml` | improved repo-static | GitHub branch protection/ruleset review |
 | OPA/Conftest feasibility undefined | Record that no OPA/Conftest gate is introduced until policy owner, bundle location, install path, and failure semantics are defined | operations policy; this plan | improved repo-static | separate policy-gate design task |
 | Vault endpoint role separation | Document host/browser `VAULT_ADDR`, in-cluster `vault-external` EndpointSlice, and Vault Kubernetes auth API endpoint roles separately | `.env.example`; operations policy | improved repo-static | live Vault/ESO readiness |
@@ -1970,6 +1970,48 @@ runtime dependencies are unavailable.
 | `.env.example` vs `.env` key-name-only compare | PASS | missing=0; extra=0 |
 | `git diff --check` | PASS | no whitespace errors |
 | live bootstrap precheck | BLOCKED | Vault, PostgreSQL, and Valkey unreachable |
+
+## Live Bootstrap Runtime Closure Overlay - 2026-05-25
+
+### Intent and Boundary
+
+This overlay records the human-approved live bootstrap follow-up after PR #40
+was merged. It continues to use the existing 006 SDD chain as the canonical
+SSoT. It does not inspect or print secret values, rewrite public Git history,
+force ArgoCD sync, or merge directly to `main`.
+
+### Runtime Closure Decisions
+
+| Area | Evidence | Decision | Follow-up |
+| --- | --- | --- | --- |
+| External dependencies | Vault, Valkey, PostgreSQL router, and k3d containers started locally; Vault health returned `200`; PostgreSQL write/read and Valkey TCP checks passed | Treat live bootstrap preconditions as satisfied for this approved run | Keep external service startup outside normal repo automation |
+| MetalLB bootstrap | MetalLB chart `0.16.0` rendered only after explicitly disabling the `frr-k8s` ServiceMonitor value; cold image pulls exceeded the previous 120s wait | Add explicit Helm value and extend MetalLB timeout to 300s | Revisit if chart defaults change again |
+| EndpointSlice boundary | ArgoCD excludes EndpointSlice resources, so only Services reconciled from `platform-external-services`; live Vault path failed until EndpointSlices were bootstrap-applied | Bootstrap applies all external-service `Service` and `EndpointSlice` resources before ESO/Vault validation | Keep Git desired state as SSoT and bootstrap as approved break-glass initializer |
+| Vault Kubernetes auth | Vault reached Kubernetes API, but login returned `403` until the current `external-secrets` serviceAccount had TokenReview permission and reviewer JWT/CA were refreshed | Add GitOps ClusterRoleBinding to `system:auth-delegator` and refresh Vault auth config during approved live recovery | Vault token reviewer refresh remains a human-approved live operation |
+| Traefik / TLS validation | Ingress `LoadBalancer` IP `172.18.0.240:443` with host/SNI resolve returned HTTP `200`; `127.0.0.1:443` is only valid when an external gateway is actually present | Make live TLS validation default to ingress-nginx LoadBalancer IP and keep external Traefik 443 as an optional check | External Traefik runtime proof remains separate from cluster bootstrap proof |
+
+### Implementation Plan Delta
+
+| Priority | Action type | Target | Change | Linked task | Verification | Rollback |
+| --- | --- | --- | --- | --- | --- | --- |
+| P1 | supplementation | Spec 006 | Add VAL-SPC-006-021 for approved live runtime closure | T-084 | repo quality gate | Revert criterion |
+| P1 | supplementation | 006 Plan/Task | Add this overlay and T-084 through T-090 | T-084, T-090 | repo quality gate; wiki check | Revert overlay sections |
+| P2 | bootstrap | `infrastructure/bootstrap-local.sh` | Set MetalLB `frr-k8s.prometheus.serviceMonitor.enabled=false`, use 300s timeout, and apply all external-service endpoints during bootstrap | T-085, T-086 | bootstrap run and shell syntax | Revert script edits |
+| P2 | GitOps RBAC | `gitops/platform/eso/` | Add `external-secrets` TokenReview ClusterRoleBinding for Vault Kubernetes auth | T-087 | `kubectl auth can-i`; ESO/Vault live check | Remove binding manifest |
+| P2 | validation | `infrastructure/tests/` | Support current MetalLB deployment name and validate TLS via ingress-nginx LoadBalancer IP | T-088 | `infrastructure/tests/run-all.sh` | Revert validation edits |
+| P1 | Traefik docs/config | `traefik/`, `.env.example`, operations policy | Align external Traefik backend wording and config with ingress-nginx LoadBalancer IP | T-089 | targeted `rg`; YAML parse | Revert wording/config edits |
+| P1 | verification | validation bundle | Run live and repo-static checks without printing secret values | T-090 | Verification Summary | Re-run after rollback |
+
+### Verification Delta
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `infrastructure/bootstrap-local.sh` | PASS | Reused `k3d-hyhome`; installed MetalLB/ArgoCD; applied external-service EndpointSlices |
+| Vault Kubernetes auth login status | PASS | metadata-only check returned HTTP `200`; JWT and Vault token were not printed |
+| `kubectl auth can-i create tokenreviews...` | PASS | `external-secrets` serviceAccount can create TokenReviews |
+| `bash infrastructure/tests/verify-secrets.sh` | PASS | `vault-backend` and `argocd-external-valkey` Ready checks passed |
+| `bash infrastructure/tests/run-all.sh` | PASS | cluster, MetalLB, GitOps, ESO/Vault, external service, network policy, and ingress/TLS checks passed |
+| External Traefik 443 | DEFERRED | optional `CHECK_TRAEFIK_443=true` remains separate because no external gateway runtime proof was requested for this branch |
 
 ## Related Documents
 

--- a/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
+++ b/docs/04.execution/tasks/2026-05-24-workspace-harness-gap-analysis.md
@@ -138,6 +138,13 @@ pre-check와 follow-up으로 남긴다.
 | T-081 | Record PR #39 merge completion and merged-main verification | doc | VAL-SPC-006-020 | Post-Merge Completion Audit | Post-Merge Completion Audit Summary | Platform | Done |
 | T-082 | Clean up the merged local PR branch without touching unrelated branches | chore | VAL-SPC-006-020 | Post-Merge Cleanup | git status and merged-branch evidence | Platform | Done |
 | T-083 | Run no-secret-output live bootstrap prechecks and record blocker state | eval | VAL-SPC-006-020 | Live Bootstrap Precheck | bootstrap precheck evidence | Platform | Done |
+| T-084 | Record approved live bootstrap runtime closure in the existing 006 SDD chain | doc | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | plan/task/spec/progress overlay | Platform | Done |
+| T-085 | Start required external runtime dependencies without printing secret values | ops | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | Docker container health and TCP checks | Platform | Done |
+| T-086 | Harden bootstrap MetalLB and external-service EndpointSlice initialization | bootstrap | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | bootstrap PASS and shell syntax | Platform | Done |
+| T-087 | Add Vault Kubernetes auth TokenReview desired-state binding and refresh live auth config | gitops | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | `can-i` and Vault login HTTP 200 | Platform | Done |
+| T-088 | Align live validation scripts with current MetalLB and ingress-nginx LoadBalancer behavior | test | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | `infrastructure/tests/run-all.sh` PASS | Platform | Done |
+| T-089 | Correct Traefik backend and fallback wording using live LoadBalancer evidence | doc | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | targeted `rg` and YAML parse | Platform | Done |
+| T-090 | Run final live and repo-static verification for the runtime closure branch | test | VAL-SPC-006-021 | Live Bootstrap Runtime Closure | Live Bootstrap Runtime Closure Summary | Platform | Done |
 
 ## Suggested Types
 
@@ -291,6 +298,21 @@ pre-check와 follow-up으로 남긴다.
       branch and leave unrelated merged branches untouched.
 - [x] T-083 Run no-secret-output live bootstrap prechecks and record that live
       bootstrap remains blocked by unreachable external services.
+
+### Phase 19 - Live Bootstrap Runtime Closure
+
+- [x] T-084 Add VAL-SPC-006-021 and this live closure overlay.
+- [x] T-085 Start Vault, Valkey, PostgreSQL router, and k3d runtime dependencies
+      without printing secret values.
+- [x] T-086 Harden MetalLB chart values/timeouts and bootstrap all external
+      service EndpointSlices.
+- [x] T-087 Add the Vault TokenReview ClusterRoleBinding and refresh live Vault
+      Kubernetes auth metadata.
+- [x] T-088 Align live validation scripts with current MetalLB and ingress
+      LoadBalancer behavior.
+- [x] T-089 Correct Traefik backend/fallback wording and reference configs based
+      on live LoadBalancer evidence.
+- [x] T-090 Run live and repo-static verification for this branch.
 
 ## Verification Evidence History Note
 
@@ -802,6 +824,53 @@ is stored in the linked plan to keep this task document concise.
   - Live bootstrap and `infrastructure/tests/run-all.sh` remain blocked until
     the external Vault, PostgreSQL, and Valkey services are running and
     reachable. No secret values were printed or manually inspected.
+
+## Live Bootstrap Runtime Closure Summary
+
+- **Scope**: 2026-05-25 approved follow-up after PR #40 was merged into
+  `main`, covering live external dependency startup, k3d bootstrap, Vault
+  Kubernetes auth repair, and runtime validation closure.
+- **Runtime Changes**:
+  - External Vault, Valkey, PostgreSQL router, and k3d containers were started
+    locally for verification; no secret values were printed.
+  - `infrastructure/bootstrap-local.sh` now pins the MetalLB `frr-k8s`
+    ServiceMonitor value to disabled, waits up to 300s for MetalLB, and
+    bootstrap-applies all external-service `Service`/`EndpointSlice` resources
+    because ArgoCD excludes EndpointSlice resources.
+  - `gitops/platform/eso/vault-token-reviewer-binding.yaml` grants the
+    `external-secrets` serviceAccount `system:auth-delegator` via
+    ClusterRoleBinding so Vault Kubernetes auth can perform TokenReview.
+  - Vault Kubernetes auth reviewer JWT/CA were refreshed in the live Vault
+    instance through an approved metadata-only operation; tokens were not
+    printed.
+  - `infrastructure/tests/verify-cluster.sh` accepts the current
+    `metallb-controller` deployment name.
+  - `infrastructure/tests/verify-ingress-tls.sh` validates the default direct
+    runtime path through ingress-nginx `LoadBalancer` IP with host/SNI resolve
+    and keeps external Traefik host 443 as an optional check.
+  - `traefik/*.yaml`, `traefik/README.md`, `.env.example`, and the operations
+    policy now align the external Traefik backend with the ingress-nginx
+    `LoadBalancer` IP path.
+- **Live Verification Evidence**:
+  - `infrastructure/bootstrap-local.sh` - PASS.
+  - Vault Kubernetes login metadata check - PASS; HTTP `200`.
+  - `kubectl auth can-i create tokenreviews.authentication.k8s.io --as system:serviceaccount:external-secrets:external-secrets` - PASS.
+  - `bash infrastructure/tests/verify-secrets.sh` - PASS.
+  - `bash infrastructure/tests/run-all.sh` - PASS.
+- **Repo-Static Verification Evidence**:
+  - `bash scripts/validate-repo-quality-gates.sh .` - PASS.
+  - `bash scripts/generate-llm-wiki-index.sh --check` - PASS.
+  - `bash scripts/validate-gitops-structure.sh` - PASS.
+  - `bash scripts/validate-k8s-manifests.sh .` - PASS.
+  - `bash scripts/check-secret-handling.sh .` - PASS.
+  - `bash infrastructure/tests/verify-contracts-static.sh` - PASS.
+  - shell syntax, JSON parse, workflow/Traefik YAML parse, env key-name-only
+    comparison, and `git diff --check` - PASS.
+- **Remaining Limitations**:
+  - External Traefik runtime proof with `CHECK_TRAEFIK_443=true` remains
+    separate because no external gateway container was started for this branch.
+  - Secret values, Vault KV values, and direct plaintext secret material were
+    not printed or manually inspected.
 
 ## Related Documents
 

--- a/docs/05.operations/policies/0002-wsl2-k3d-gitops-ha-operations-policy.md
+++ b/docs/05.operations/policies/0002-wsl2-k3d-gitops-ha-operations-policy.md
@@ -35,11 +35,11 @@ updated: 2026-05-25
   - Vault 경로 표준(`secret/platform/argocd`, `secret/platform/postgres-app`)
   - ArgoCD host=`argocd.127.0.0.1.nip.io`, TLS secret=`argocd-local-tls` # pragma: allowlist secret
   - `ingress-nginx-controller`는 `LoadBalancer` 타입 유지
-  - 외부 Traefik `websecure/443`은 Docker 네트워크의
-    `k3d-hyhome-serverlb:443`으로 라우팅
-  - direct fallback 검증은 호스트 포트 충돌 시
-    `ARGOCD_FALLBACK_PORT=8443` 경로를 사용할 수 있으며, 외부 Traefik
-    backend 포트와 혼동하지 않음
+  - 외부 Traefik `websecure/443`은 Docker 네트워크에서 접근 가능한
+    ingress-nginx `LoadBalancer` IP(`172.18.0.240:443`)로 라우팅
+  - direct runtime TLS 검증은 기본적으로 ingress-nginx `LoadBalancer` IP와
+    host/SNI resolve를 사용하며, 호스트 포트 충돌 검증 시에만
+    `ARGOCD_FALLBACK_PORT=8443` 경로를 명시
   - AppProject `apps` wildcard 금지 + 최소 allow-list 유지
   - `argocd` egress는 Valkey + DNS + HTTPS 허용
   - CI 정적 게이트 필수화(`branch-policy`, `pre-commit`,
@@ -116,8 +116,8 @@ updated: 2026-05-25
 - `argocd` egress 정책에서 DNS/HTTPS 누락 여부
 - 현재 CI 정적 게이트(`branch-policy`, `pre-commit`, `repo-quality-static`,
   `manifest-static`, `shell-static`) 유지 여부
-- 외부 Traefik 계약(`websecure/443 -> k3d-hyhome-serverlb:443`)과 direct
-  fallback 포트(`ARGOCD_FALLBACK_PORT`) 변경 이력
+- 외부 Traefik 계약(`websecure/443 -> ingress-nginx LoadBalancer IP:443`)과
+  direct fallback 포트(`ARGOCD_FALLBACK_PORT`) 변경 이력
 - OPA/Conftest 도입 여부와 policy owner/bundle/install path 결정 상태
 
 ## Related Documents

--- a/docs/05.operations/runbooks/0002-argocd-eso-vault-recovery-runbook.md
+++ b/docs/05.operations/runbooks/0002-argocd-eso-vault-recovery-runbook.md
@@ -147,7 +147,8 @@ kubectl -n argocd get app root-platform -o yaml | \
 - [ ] 포트/서비스 계약 회귀 없음
 - [ ] `argocd` egress(Valkey + DNS + HTTPS) 통과
 - [ ] ingress/TLS 계약(host=`argocd.127.0.0.1.nip.io`, secret=`argocd-local-tls`) 유지 # pragma: allowlist secret
-- [ ] Traefik 443 및 fallback 8443 HTTPS 응답 확인
+- [ ] ingress-nginx LoadBalancer IP 기반 HTTPS 응답 확인; 외부 Traefik 443
+      확인은 gateway 런타임이 준비된 경우에만 별도 수행
 - [ ] CI 정적 계약(`verify-contracts-static.sh`) 통과
 
 ## Observability and Evidence Sources

--- a/gitops/platform/eso/kustomization.yaml
+++ b/gitops/platform/eso/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - vault-token-reviewer-binding.yaml
   - vault-secret-store.yaml
   - postgres-app-secret.yaml

--- a/gitops/platform/eso/vault-token-reviewer-binding.yaml
+++ b/gitops/platform/eso/vault-token-reviewer-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-vault-token-reviewer
+  annotations:
+    platform.hyhome.io/purpose: vault-kubernetes-auth-token-reviewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets

--- a/infrastructure/bootstrap-local.sh
+++ b/infrastructure/bootstrap-local.sh
@@ -205,7 +205,8 @@ helm repo add metallb https://metallb.github.io/metallb
 helm repo update metallb
 helm upgrade --install metallb metallb/metallb \
   -n metallb-system --create-namespace \
-  --wait --timeout=120s
+  --set frr-k8s.prometheus.serviceMonitor.enabled=false \
+  --wait --timeout=300s
 kubectl apply -f "$ROOT_DIR/infrastructure/ipaddresspool.yaml"
 kubectl apply -f "$ROOT_DIR/infrastructure/l2advertisement.yaml"
 
@@ -226,9 +227,9 @@ kubectl -n cert-manager create secret tls mkcert-root-ca \
   --key="$ROOT_CA_KEY_FILE" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-echo "[7.5/11] Pre-create platform namespace and valkey-external service"
+echo "[7.5/11] Pre-create platform namespace and external service endpoints"
 kubectl create namespace platform --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f "$ROOT_DIR/gitops/platform/external-services/valkey-external.yaml"
+kubectl apply -k "$ROOT_DIR/gitops/platform/external-services"
 
 echo "[8/11] Install ArgoCD via Helm"
 helm repo add argo https://argoproj.github.io/argo-helm

--- a/infrastructure/tests/verify-cluster.sh
+++ b/infrastructure/tests/verify-cluster.sh
@@ -26,8 +26,12 @@ fi
 echo "[PASS] cluster topology check passed (nodes=$node_count, ready=$ready_count)"
 
 echo "[INFO] Checking MetalLB readiness"
-metallb_ready="$(kubectl -n metallb-system get deploy controller \
+metallb_ready="$(kubectl -n metallb-system get deploy metallb-controller \
   -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+if [ "${metallb_ready:-0}" -lt 1 ]; then
+  metallb_ready="$(kubectl -n metallb-system get deploy controller \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+fi
 [ "${metallb_ready:-0}" -ge 1 ] || \
   fail "metallb controller is not ready (readyReplicas=${metallb_ready:-0})"
 

--- a/infrastructure/tests/verify-ingress-tls.sh
+++ b/infrastructure/tests/verify-ingress-tls.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ARGOCD_HOST="${ARGOCD_HOST:-argocd.127.0.0.1.nip.io}"
-ARGOCD_FALLBACK_PORT="${ARGOCD_FALLBACK_PORT:-8443}"
+ARGOCD_FALLBACK_PORT_WAS_SET="${ARGOCD_FALLBACK_PORT+x}"
+ARGOCD_FALLBACK_PORT="${ARGOCD_FALLBACK_PORT:-443}"
+ARGOCD_FALLBACK_IP="${ARGOCD_FALLBACK_IP:-}"
 CHECK_TRAEFIK_443="${CHECK_TRAEFIK_443:-false}"
 
 fail() {
@@ -19,6 +21,17 @@ kubectl version --request-timeout=5s >/dev/null 2>&1 || \
 svc_type="$(kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.spec.type}' 2>/dev/null || true)"
 [ "$svc_type" = "LoadBalancer" ] || fail "ingress-nginx-controller type mismatch (actual=$svc_type)"
 
+ingress_lb_ip="$(kubectl -n ingress-nginx get svc ingress-nginx-controller \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+if [ -z "$ARGOCD_FALLBACK_IP" ]; then
+  if [ -z "$ARGOCD_FALLBACK_PORT_WAS_SET" ]; then
+    ARGOCD_FALLBACK_IP="$ingress_lb_ip"
+  else
+    ARGOCD_FALLBACK_IP="127.0.0.1"
+  fi
+fi
+[ -n "$ARGOCD_FALLBACK_IP" ] || fail "ingress-nginx-controller LoadBalancer IP is empty"
+
 ing_host="$(kubectl -n argocd get ingress argocd-server -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
 [ "$ing_host" = "$ARGOCD_HOST" ] || fail "argocd ingress host mismatch (actual=$ing_host)"
 
@@ -31,8 +44,10 @@ tls_secret="$(kubectl -n argocd get ingress argocd-server -o jsonpath='{.spec.tl
 secret_type="$(kubectl -n argocd get secret argocd-local-tls -o jsonpath='{.type}' 2>/dev/null || true)"
 [ "$secret_type" = "kubernetes.io/tls" ] || fail "argocd-local-tls type mismatch (actual=$secret_type)"
 
-curl -kIs --max-time 5 "https://${ARGOCD_HOST}:${ARGOCD_FALLBACK_PORT}" >/tmp/argocd-tls-fallback.txt 2>/dev/null || \
-  fail "https fallback endpoint is not reachable (${ARGOCD_HOST}:${ARGOCD_FALLBACK_PORT})"
+curl -kIs --max-time 5 \
+  --resolve "${ARGOCD_HOST}:${ARGOCD_FALLBACK_PORT}:${ARGOCD_FALLBACK_IP}" \
+  "https://${ARGOCD_HOST}:${ARGOCD_FALLBACK_PORT}" >/tmp/argocd-tls-fallback.txt 2>/dev/null || \
+  fail "https fallback endpoint is not reachable (${ARGOCD_HOST}:${ARGOCD_FALLBACK_PORT} via ${ARGOCD_FALLBACK_IP})"
 rg -q '^HTTP/' /tmp/argocd-tls-fallback.txt || \
   fail "https fallback endpoint did not return HTTP response"
 

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -12,13 +12,14 @@ Ingress NGINX는 2026-03-24 이후 upstream retired 상태이므로 cloud target
 
 ## Port Contract
 
-- 외부 Traefik은 `websecure/443`에서 요청을 받고 Docker 네트워크의
-  `k3d-hyhome-serverlb:443`으로 전달한다.
-- `infrastructure/bootstrap-local.sh`는 호스트 443 포트가 이미 사용 중이면
-  direct browser fallback을 위해 `K3D_HTTPS_PORT=8443`으로 전환할 수 있다.
-- `ARGOCD_FALLBACK_PORT=8443`은 direct host 접근 검증용 fallback 포트이며,
-  `traefik/*.yaml`의 backend URL(`https://k3d-hyhome-serverlb:443`)을 8443으로
-  바꾸라는 의미가 아니다.
+- 외부 Traefik은 `websecure/443`에서 요청을 받고 Docker 네트워크에서 접근
+  가능한 ingress-nginx `LoadBalancer` IP(`172.18.0.240:443`)로 전달한다.
+- `infrastructure/bootstrap-local.sh`의 k3d host port fallback은 k3d
+  serverlb host binding용이며, MetalLB가 할당한 ingress-nginx
+  `LoadBalancer` IP 검증 경로와 혼동하지 않는다.
+- `ARGOCD_FALLBACK_PORT`를 직접 지정하지 않으면 live TLS 검증은
+  ingress-nginx `LoadBalancer` IP와 host/SNI resolve를 사용한다. 직접
+  host port fallback을 검증할 때만 `ARGOCD_FALLBACK_PORT=8443`처럼 명시한다.
 - 이 디렉터리의 파일은 외부 Traefik dynamic config 참조 복사본이므로,
   live gateway 반영은 `hy-home.docker` 운영 절차에서 별도로 승인하고
   증적을 남긴다.

--- a/traefik/argocd-k3d.yaml
+++ b/traefik/argocd-k3d.yaml
@@ -9,7 +9,7 @@ http:
         passHostHeader: true
         serversTransport: argocd-k3d-transport
         servers:
-          - url: "https://k3d-hyhome-serverlb:443"
+          - url: "https://172.18.0.240:443"
 
   routers:
     argocd-k3d:

--- a/traefik/headlamp-k3d.yaml
+++ b/traefik/headlamp-k3d.yaml
@@ -3,8 +3,8 @@
 # Pattern mirrors argocd-k3d.yaml.
 #
 # Traffic flow:
-#   Browser → Traefik (websecure/443) → k3d-hyhome-serverlb:443
-#     → ingress-nginx LoadBalancer → Headlamp service (headlamp:4466)
+#   Browser → Traefik (websecure/443) → ingress-nginx LoadBalancer IP:443
+#     → Headlamp service (headlamp:4466)
 #
 # TLS: Traefik terminates with its own cert (nip.io wildcard or mkcert).
 #      insecureSkipVerify=true skips validation of the ingress-nginx
@@ -21,7 +21,7 @@ http:
         passHostHeader: true
         serversTransport: headlamp-k3d-transport
         servers:
-          - url: 'https://k3d-hyhome-serverlb:443'
+          - url: 'https://172.18.0.240:443'
 
   routers:
     headlamp-k3d:

--- a/traefik/kiali-k3d.yaml
+++ b/traefik/kiali-k3d.yaml
@@ -3,8 +3,8 @@
 # Pattern mirrors argocd-k3d.yaml.
 #
 # Traffic flow:
-#   Browser → Traefik (websecure/443) → k3d-hyhome-serverlb:443
-#     → ingress-nginx LoadBalancer → Kiali service (istio-system:20001)
+#   Browser → Traefik (websecure/443) → ingress-nginx LoadBalancer IP:443
+#     → Kiali service (istio-system:20001)
 #
 # TLS: Traefik terminates with its own cert (nip.io wildcard or mkcert).
 #      insecureSkipVerify=true skips validation of the ingress-nginx
@@ -21,7 +21,7 @@ http:
         passHostHeader: true
         serversTransport: kiali-k3d-transport
         servers:
-          - url: 'https://k3d-hyhome-serverlb:443'
+          - url: 'https://172.18.0.240:443'
 
   routers:
     kiali-k3d:

--- a/traefik/rollouts-k3d.yaml
+++ b/traefik/rollouts-k3d.yaml
@@ -3,8 +3,8 @@
 # Pattern mirrors argocd-k3d.yaml.
 #
 # Traffic flow:
-#   Browser → Traefik (websecure/443) → k3d-hyhome-serverlb:443
-#     → ingress-nginx LoadBalancer → Rollouts Dashboard service (argo-rollouts:3100)
+#   Browser → Traefik (websecure/443) → ingress-nginx LoadBalancer IP:443
+#     → Rollouts Dashboard service (argo-rollouts:3100)
 #
 # TLS: Traefik terminates with its own cert (nip.io wildcard or mkcert).
 #      insecureSkipVerify=true skips validation of the ingress-nginx
@@ -21,7 +21,7 @@ http:
         passHostHeader: true
         serversTransport: rollouts-k3d-transport
         servers:
-          - url: 'https://k3d-hyhome-serverlb:443'
+          - url: 'https://172.18.0.240:443'
 
   routers:
     rollouts-k3d:


### PR DESCRIPTION
# PULL REQUEST TEMPLATE

## 1. Description

Closes the approved live bootstrap/runtime validation gaps found after PR #40 merged. This updates bootstrap and validation contracts for current MetalLB, ArgoCD EndpointSlice exclusion, Vault Kubernetes auth TokenReview, ingress-nginx LoadBalancer TLS validation, and Traefik backend references.

## 2. Related Issue

Fixes # (not applicable)

## 3. Branch Target

- [x] This PR targets `main`; any exception must update CI `branch-policy` and governance in the same change.
- [x] No PR targeting `main` bypasses CI or branch-policy checks.
- [x] Draft/WIP status is intentional; this PR is ready for review after required checks pass.
- [x] The source branch uses an approved prefix: `codex/`.
- [x] CI `branch-policy` validates pull request shape; GitHub branch protection/rulesets enforce direct-push restrictions.

## 4. Type of Change

- [x] `fix`: Bug fix
- [x] `docs`: Documentation updates
- [x] `test`: Tests or validation updates
- [x] `infra`: Changes to Kubernetes manifests or GitOps assets

## 5. Breaking Changes

- [ ] Yes
- [x] No

## 6. How Has This Been Tested?

- [x] Relevant `pre-commit` hooks passed during commit.
- [x] `bash scripts/validate-repo-quality-gates.sh .` successful.
- [x] `bash scripts/generate-llm-wiki-index.sh --check` successful.
- [x] `bash infrastructure/tests/verify-contracts-static.sh` successful.
- [x] `bash scripts/validate-gitops-structure.sh` successful.
- [x] `bash scripts/validate-k8s-manifests.sh .` successful.
- [x] `bash scripts/check-secret-handling.sh .` successful.
- [x] ArgoCD/GitOps impact reviewed.
- [x] Coverage policy reviewed for Bash/YAML/Markdown infrastructure validation.
- [ ] No live cluster mutation, `kubectl apply`, or external Vault mutation was introduced. Approved live validation did run bootstrap/apply and Vault Kubernetes auth metadata refresh without printing secret values; these actions are recorded under VAL-SPC-006-021.

Additional live checks:

- [x] `KUBECONFIG=/tmp/k3d-hyhome-kubeconfig bash infrastructure/tests/run-all.sh` successful.
- [x] Vault Kubernetes login metadata check returned HTTP 200 without printing JWT or Vault token.
- [x] `kubectl auth can-i create tokenreviews.authentication.k8s.io --as system:serviceaccount:external-secrets:external-secrets` successful.
- [x] shell syntax, JSON parse, workflow/Traefik YAML parse, `.env` key-name-only comparison, and `git diff --check` successful.

## 7. Checklist

- [x] My change follows the governance and workflow rules in `AGENTS.md` and `docs/00.agent-governance/`.
- [x] I have updated the documentation accordingly.
- [x] My commit messages follow Conventional Commits.
- [x] I did not introduce plaintext secrets. Secret-related changes use GitOps-approved patterns only.
